### PR TITLE
Updated Readme with more information on git lfs pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Note : GitHub has recently changed the versioning for large files. To be able to
 After cloning the repository execute the following command to make sure all files are pulled.
 
 	git lfs pull
+
+Alternatively you can specify the repo with:
+
+    git lfs pull https://github.com/Acuant/AcuantiOSMobileSDK.git
 	
 ## Common Error
 


### PR DESCRIPTION
`git lfs pull` would not work. I had to explicitly state the repo in order to pull the additional files down with: `git lfs pull https://github.com/Acuant/AcuantiOSMobileSDK.git`